### PR TITLE
chore: bump docker-compose version to 1.29.1 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ branches:
   only:
   - master
 
+env:
+  - DOCKER_COMPOSE_VERSION=1.29.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+
 script:
   - docker --version # print the version for logging
   - docker-compose --version


### PR DESCRIPTION
closes #16 